### PR TITLE
IDE-3706 Match error for 70 sdk layout template xml file

### DIFF
--- a/tools/plugins/com.liferay.ide.layouttpl.core/src/com/liferay/ide/layouttpl/core/operation/LayoutTplDescriptorHelper.java
+++ b/tools/plugins/com.liferay.ide.layouttpl.core/src/com/liferay/ide/layouttpl/core/operation/LayoutTplDescriptorHelper.java
@@ -104,7 +104,11 @@ public class LayoutTplDescriptorHelper extends LiferayDescriptorHelper implement
 		String thumbnailPath = model.getStringProperty(LAYOUT_THUMBNAIL_FILE);
 
 		NodeUtil.appendChildElement(layoutTemplateElement, "template-path", templatePath);
-		NodeUtil.appendChildElement(layoutTemplateElement, "wap-template-path", wapTemplatePath);
+
+		if (getDescriptorVersion().equals("6.2.0")) {
+			NodeUtil.appendChildElement(layoutTemplateElement, "wap-template-path", wapTemplatePath);
+		}
+
 		NodeUtil.appendChildElement(layoutTemplateElement, "thumbnail-path", thumbnailPath);
 
 		// format the new node added to the model;


### PR DESCRIPTION
The version 70 dont need element "wap-template-path", only version 62 need it.